### PR TITLE
Bump SDL2Sharp to v0.3.6.

### DIFF
--- a/sources/FFmpegSharp.Extensions.Framework/FFmpegSharp.Extensions.Framework.csproj
+++ b/sources/FFmpegSharp.Extensions.Framework/FFmpegSharp.Extensions.Framework.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SDL2Sharp" Version="0.3.1" />
-    <PackageReference Include="SDL2Sharp.Extensions" Version="0.3.1" />
+    <PackageReference Include="SDL2Sharp" Version="0.3.6" />
+    <PackageReference Include="SDL2Sharp.Extensions" Version="0.3.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Rationale: SDL2Sharp v0.3.6 contains the fix for "A callback was made on a garbage collected delegate [...]"